### PR TITLE
Fix recorder so that it doesnt capture all environment variables

### DIFF
--- a/PowerSession.Main/Commands/RecordCommand.cs
+++ b/PowerSession.Main/Commands/RecordCommand.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections;
+    using System.Collections.Generic;
     using System.IO;
     using ConPTY;
     using Newtonsoft.Json;
@@ -67,7 +68,7 @@
         {
             if (string.IsNullOrEmpty(command)) command = "powershell.exe";
 
-            if (_env == null) _env = Environment.GetEnvironmentVariables();
+            if (_env == null) _env = new Dictionary<string, string>();
             _env.Add("POWERSESSION_RECORDING", "1");
             _env.Add("SHELL", "powershell.exe");
             _env.Add("TERM", Environment.GetEnvironmentVariable("TERMINAL_EMULATOR") ?? "NotSure");
@@ -81,7 +82,7 @@
                 Environment = _env
             };
             writer.SetHeader(headerInfo);
-            
+
             var terminal = new Terminal(writer.GetInputStream(), writer.GetWriteStream(), width: headerInfo.Width, height: headerInfo.Height);
             terminal.Record(command, _env);
             Console.WriteLine("Record Finished");


### PR DESCRIPTION
This PR addresses Issue #9 

The fix is quite simple, basically my approach was to create a new object for storing/writing the variables instead of directly working with the environment. This way, only explicitly requested variables are captured.