### PR TITLE
Use Convert.ToDouble rather than a cast to get the Timestamp

### DIFF
--- a/PowerSession.Main/Commands/RecordSession.cs
+++ b/PowerSession.Main/Commands/RecordSession.cs
@@ -47,7 +47,7 @@
                 if (lineData.Count != 3) throw new InvalidDataException("Invalid record data");
                 var rv = new SessionLine
                 {
-                    Timestamp = (double) lineData[0],
+                    Timestamp = Convert.ToDouble(lineData[0]),
                     Stdout = (string) lineData[1] == "o",
                     Content = (string) lineData[2]
                 };


### PR DESCRIPTION
Post-processing tools (between rec and play/upload) can serialize timestamps as integers which cause PowerSession to throw when casting to `double`. Rather than forcing decimal places use `Convert` to mitigate the cast exception.